### PR TITLE
fix forge install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/openzeppelin/openzeppelin-contracts
 [submodule "lib/openzeppelin-contracts-upgradeable-4.3.1"]
 	path = lib/openzeppelin-contracts-upgradeable-4.3.1
-	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
+	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable@v4.3.1


### PR DESCRIPTION
Due to using OZ upgradeable contracts with 2 different versions, forge install is failing on the main branch. 